### PR TITLE
add option to set an upper limit on expansions included in a set

### DIFF
--- a/DominionCompanion/utilities/Constants.swift
+++ b/DominionCompanion/utilities/Constants.swift
@@ -13,6 +13,7 @@ struct Constants {
     static let notGameplayRelatedTypes = ["Boon", "Hex", "Ruins"]
     struct SaveKeys {
         static let maxKingdomCards = "maxKingdomCards"
+        static let maxExpansions = "maxExpansions"
         static let chosenExpansions = "expansions"
         
         static let pinnedRules = "pinnedRules"

--- a/DominionCompanion/utilities/Settings.swift
+++ b/DominionCompanion/utilities/Settings.swift
@@ -12,6 +12,8 @@ class Settings {
     static let shared = Settings()
     
     @UserDefaultsBacked(Constants.SaveKeys.maxKingdomCards) var maxKingdomCards: Int = 10
+
+    @UserDefaultsBacked(Constants.SaveKeys.maxExpansions) var maxExpansions: Int = 10
     
     @UserDefaultsBacked(Constants.SaveKeys.chosenExpansions) var chosenExpansions: [String] = []
     

--- a/DominionCompanion/viewModels/SetBuilderModel.swift
+++ b/DominionCompanion/viewModels/SetBuilderModel.swift
@@ -136,15 +136,16 @@ class SetBuilderModel: ObservableObject, RuleBuilder {
         
         let cardCopy = self.cardData.cardsFromChosenExpansions
         guard rules.count > 0 else {
-            return completion(
-                .success(
-                    pinned + Array(
-                        cardCopy.shuffled().filter {
-                            !pinned.contains($0)
-                        }[0..<(Settings.shared.maxKingdomCards - pinned.count)]
-                    )
-                )
-            )
+            var set = pinned
+            for card in cardCopy.shuffled() {
+                let tempSet = set + [card]
+                guard Set(tempSet.map(\.expansion)).count <= Settings.shared.maxExpansions else { continue }
+                set.append(card)
+                if set.count == Settings.shared.maxKingdomCards {
+                    break
+                }
+            }
+            return completion(.success(set))
         }
         guard rulesCanBeSatisfied(cardCopy, self.rules) else {
             Logger.shared.w("A set cannot be made with the current rules")
@@ -188,6 +189,8 @@ class SetBuilderModel: ObservableObject, RuleBuilder {
 
                 // The potential next version of the set being built
                 let tempSet = finalSet + [nextCard]
+
+                guard Set(tempSet.map(\.expansion)).count <= Settings.shared.maxExpansions else { continue }
                 
                 // Calculate satisfactions for each rule
                 let newSatisfactions = self.rules.map { $0.satisfaction(tempSet) }

--- a/DominionCompanion/views/Settings/SettingsView.swift
+++ b/DominionCompanion/views/Settings/SettingsView.swift
@@ -24,6 +24,7 @@ struct SettingsView: View {
     @AppStorage(Constants.SaveKeys.settingsNumWays) var maxWays: Int = 0
 
     @AppStorage(Constants.SaveKeys.maxKingdomCards) var maxKingdomCards: Int = Settings.shared.maxKingdomCards
+    @AppStorage(Constants.SaveKeys.maxExpansions) var maxExpansions: Int = Settings.shared.maxExpansions
     
     // MARK: App Behavior
     @AppStorage(Constants.SaveKeys.settingsHideWikiLink) var hideWikiLinks: Bool = false
@@ -56,6 +57,9 @@ struct SettingsView: View {
                     }
                     ListChoice(title: "Maximum Kingdom Cards", value: "\(maxKingdomCards)", values: ["10", "11", "12", "13", "14", "15", "16"]) { val in
                         maxKingdomCards = Int(val) ?? 10
+                    }
+                    ListChoice(title: "Maximum Expansions in Set", value: "\(maxExpansions)", values: ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]) { val in
+                        maxExpansions = Int(val) ?? 10
                     }
                 }
                 Section(header: Text("App Behavior")) {


### PR DESCRIPTION
Resolves #15 

Adds a settings option to set a limit on the number of expansions that can be in a set