### PR TITLE
allow adding a precondition to a rule, to conditionally enable the rule

### DIFF
--- a/DominionCompanion.xcodeproj/project.pbxproj
+++ b/DominionCompanion.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		AF34B1CD25F59490007E241C /* SetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF34B1CC25F59490007E241C /* SetModelTests.swift */; };
 		AF4E49F8252916FE00410D10 /* RuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4E49F7252916FE00410D10 /* RuleView.swift */; };
 		AF4E49FD25291D3100410D10 /* ConditionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4E49FC25291D3100410D10 /* ConditionRow.swift */; };
+		AF540F2C267D0EE900C8ECD9 /* RuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */; };
 		AF5855F125C7517300D7A7AE /* PotionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5855F025C7517300D7A7AE /* PotionView.swift */; };
 		AF60BC5E253CDEA100DC50DE /* GlobalExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF60BC5D253CDEA100DC50DE /* GlobalExclusions.swift */; };
 		AF60BC63253CE6BD00DC50DE /* GameplaySetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */; };
@@ -109,6 +110,7 @@
 		AF34B1CC25F59490007E241C /* SetModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetModelTests.swift; sourceTree = "<group>"; };
 		AF4E49F7252916FE00410D10 /* RuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleView.swift; sourceTree = "<group>"; };
 		AF4E49FC25291D3100410D10 /* ConditionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionRow.swift; sourceTree = "<group>"; };
+		AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleViewModel.swift; sourceTree = "<group>"; };
 		AF5855F025C7517300D7A7AE /* PotionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotionView.swift; sourceTree = "<group>"; };
 		AF60BC5D253CDEA100DC50DE /* GlobalExclusions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalExclusions.swift; sourceTree = "<group>"; };
 		AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySetup.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 			children = (
 				AF1A5E4C25259A5D0050DE4E /* SetBuilderModel.swift */,
 				AF679A2025FED9D700CCF22B /* CardFilter.swift */,
+				AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */,
 			);
 			path = viewModels;
 			sourceTree = "<group>";
@@ -544,6 +547,7 @@
 				AF1A5E6025290FBE0050DE4E /* RulesView.swift in Sources */,
 				AF80D70A2364DA9800FDC4D6 /* Constants.swift in Sources */,
 				AF34B1AB25F42D76007E241C /* Disclosures.swift in Sources */,
+				AF540F2C267D0EE900C8ECD9 /* RuleViewModel.swift in Sources */,
 				AF1A5E3425255F140050DE4E /* CardView.swift in Sources */,
 				AFD02B97246CB87900D14D61 /* RecommendedSets.swift in Sources */,
 				AF1B6EAC2324226800ADA74D /* CardData.swift in Sources */,

--- a/DominionCompanion/viewModels/RuleViewModel.swift
+++ b/DominionCompanion/viewModels/RuleViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  RuleViewModel.swift
+//  DominionCompanion
+//
+//  Created by Harris Borawski on 6/18/21.
+//  Copyright © 2021 Harris Borawski. All rights reserved.
+//
+
+import Foundation
+
+class RuleViewModel: ObservableObject, RuleBuilder {
+
+    @Published var precondition: Rule?
+
+    @Published var rules: [Rule] = [] {
+        didSet {
+            precondition = rules.first
+        }
+    }
+
+    func removeRule(_ indexSet: IndexSet) {
+        self.rules.remove(atOffsets: indexSet)
+    }
+
+    func addRule(_ rule: Rule) {
+        self.rules = [rule]
+    }
+}

--- a/DominionCompanion/views/Rules/RuleRow.swift
+++ b/DominionCompanion/views/Rules/RuleRow.swift
@@ -13,6 +13,9 @@ struct RuleRow<Builder: RuleBuilder>: View  where Builder: ObservableObject  {
     @ObservedObject var ruleBuilder: Builder
     var body: some View {
         HStack {
+            if rule.precondition != nil {
+                Image(systemName: "questionmark.diamond")
+            }
             HStack {
                 Image("Card")
                 Text(rule.operation.rawValue)

--- a/DominionCompanion/views/Rules/RuleView.swift
+++ b/DominionCompanion/views/Rules/RuleView.swift
@@ -15,6 +15,14 @@ struct RuleView<Builder: RuleBuilder>: View  where Builder: ObservableObject {
     var existing: Rule?
 
     var matchSet: Bool = true
+
+    var configurePrecondition: Bool = true
+
+    var preconditionRuleBuilder = RuleViewModel()
+
+    var preconditionRule: Rule? {
+        preconditionRuleBuilder.precondition
+    }
     
     var rule: Rule {
         Rule(value: 0, operation: .greater, conditions: conditions)
@@ -66,6 +74,20 @@ struct RuleView<Builder: RuleBuilder>: View  where Builder: ObservableObject {
                         }
                     }
                 }
+                if configurePrecondition {
+                    Section(header: Text("Precondition")) {
+                        NavigationLink(
+                            destination: RuleView<RuleViewModel>(ruleBuilder: preconditionRuleBuilder, existing: preconditionRule, configurePrecondition: false),
+                            label: {
+                                HStack {
+                                    Image(systemName: "questionmark.diamond")
+                                    Text("Precondition")
+                                    Spacer()
+                                    Text(preconditionRuleBuilder.precondition == nil ? "None" : "Configured").foregroundColor(.secondary)
+                                }
+                            })
+                    }
+                }
             }
             Section(header: Text("Conditions")) {
                 Button("Add Condition") {
@@ -87,7 +109,7 @@ struct RuleView<Builder: RuleBuilder>: View  where Builder: ObservableObject {
         }
         .navigationBarItems(trailing: HStack {
             Button("Save") {
-                let newRule = Rule(value: value, operation: operation, conditions: conditions)
+                let newRule = Rule(value: value, operation: operation, conditions: conditions, precondition: preconditionRuleBuilder.precondition)
                 if let id = self.id {
                     newRule.id = id
                 }
@@ -101,6 +123,9 @@ struct RuleView<Builder: RuleBuilder>: View  where Builder: ObservableObject {
                 value = existingRule.value
                 conditions = existingRule.conditions
                 id = existingRule.id
+                if let pre = existingRule.precondition {
+                    preconditionRuleBuilder.addRule(pre)
+                }
             }
         }
     }

--- a/DominionCompanion/views/Rules/RulesView.swift
+++ b/DominionCompanion/views/Rules/RulesView.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-struct RulesView<Builder: RuleBuilder>: View  where Builder: ObservableObject {
+struct RulesView<Builder: RuleBuilder>: View where Builder: ObservableObject {
     @ObservedObject var ruleBuilder: Builder
 
     var toolbarItem: Button<Image>? = nil

--- a/UnitTests/viewModels/SetBuilderModelTests.swift
+++ b/UnitTests/viewModels/SetBuilderModelTests.swift
@@ -312,6 +312,37 @@ class SetBuilderModelTests: XCTestCase {
         wait(for: [expecation], timeout: 20) // long timeout because github actions is on the slower side
     }
 
+    func testGetMatchingSetOneRuleWithPrecondition() {
+        let data = CardData()
+        let model = SetBuilderModel(data)
+
+        let rule = Rule(value: 1, operation: .greaterOrEqual, conditions: [
+            Condition(property: .type, operation: .equal, comparisonValue: "Reaction")
+        ],
+        precondition: Rule(value: 1, operation: .greaterOrEqual, conditions: [
+            Condition(property: .type, operation: .equal, comparisonValue: "Attack")
+        ])
+        )
+
+        model.addRule(rule)
+
+        let expecation = XCTestExpectation(description: "Set Matches Rule")
+        model.getMatchingSet([TestData.getCard("Torturer")]) { result in
+            switch result {
+            case .success(let cards):
+                guard
+                    cards.first(where: { $0.types.contains("Attack") }) != nil,
+                    cards.first(where: { $0.types.contains("Reaction") }) != nil
+                else { return XCTFail() }
+                expecation.fulfill()
+            case .failure:
+                XCTFail()
+            }
+        }
+
+        wait(for: [expecation], timeout: 20) // long timeout because github actions is on the slower side
+    }
+
     func testGetMatchingSetWithExpansionLimit() {
         Settings.shared.maxExpansions = 3
         let data = CardData()


### PR DESCRIPTION
This way you can create rules to do things like including a reaction card only if there is an attack card in the set

if the precondition is not met on a rule, the rule is considered satisfied