### PR TITLE
Black market

### DIFF
--- a/DominionCompanion.xcodeproj/project.pbxproj
+++ b/DominionCompanion.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		AF540F2C267D0EE900C8ECD9 /* RuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */; };
 		AF540F36267D574800C8ECD9 /* BlackMarketSimulatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F35267D574800C8ECD9 /* BlackMarketSimulatorView.swift */; };
 		AF540F3C267D577B00C8ECD9 /* BlackMarketSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F3B267D577B00C8ECD9 /* BlackMarketSimulator.swift */; };
+		AF540F40267D6CDC00C8ECD9 /* BlackMarketSimulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F3F267D6CDC00C8ECD9 /* BlackMarketSimulatorTests.swift */; };
 		AF5855F125C7517300D7A7AE /* PotionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5855F025C7517300D7A7AE /* PotionView.swift */; };
 		AF60BC5E253CDEA100DC50DE /* GlobalExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF60BC5D253CDEA100DC50DE /* GlobalExclusions.swift */; };
 		AF60BC63253CE6BD00DC50DE /* GameplaySetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */; };
@@ -115,6 +116,7 @@
 		AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleViewModel.swift; sourceTree = "<group>"; };
 		AF540F35267D574800C8ECD9 /* BlackMarketSimulatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlackMarketSimulatorView.swift; sourceTree = "<group>"; };
 		AF540F3B267D577B00C8ECD9 /* BlackMarketSimulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlackMarketSimulator.swift; sourceTree = "<group>"; };
+		AF540F3F267D6CDC00C8ECD9 /* BlackMarketSimulatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlackMarketSimulatorTests.swift; sourceTree = "<group>"; };
 		AF5855F025C7517300D7A7AE /* PotionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotionView.swift; sourceTree = "<group>"; };
 		AF60BC5D253CDEA100DC50DE /* GlobalExclusions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalExclusions.swift; sourceTree = "<group>"; };
 		AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySetup.swift; sourceTree = "<group>"; };
@@ -363,6 +365,7 @@
 			children = (
 				AFBD15CF25EC46B50002275A /* SetBuilderModelTests.swift */,
 				AF679A2425FEDCF000CCF22B /* CardFilterTests.swift */,
+				AF540F3F267D6CDC00C8ECD9 /* BlackMarketSimulatorTests.swift */,
 			);
 			path = viewModels;
 			sourceTree = "<group>";
@@ -602,6 +605,7 @@
 				AFBD15BA25EAF02C0002275A /* RuleTypeTests.swift in Sources */,
 				AFBD15AC25EAE5710002275A /* CardTests.swift in Sources */,
 				AFE908E925C4D21D00E8334E /* UtilitiesTest.swift in Sources */,
+				AF540F40267D6CDC00C8ECD9 /* BlackMarketSimulatorTests.swift in Sources */,
 				AFE9090725C4D9F500E8334E /* ConditionTests.swift in Sources */,
 				AF679A2525FEDCF000CCF22B /* CardFilterTests.swift in Sources */,
 			);

--- a/DominionCompanion.xcodeproj/project.pbxproj
+++ b/DominionCompanion.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		AF4E49F8252916FE00410D10 /* RuleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4E49F7252916FE00410D10 /* RuleView.swift */; };
 		AF4E49FD25291D3100410D10 /* ConditionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF4E49FC25291D3100410D10 /* ConditionRow.swift */; };
 		AF540F2C267D0EE900C8ECD9 /* RuleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */; };
+		AF540F36267D574800C8ECD9 /* BlackMarketSimulatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F35267D574800C8ECD9 /* BlackMarketSimulatorView.swift */; };
+		AF540F3C267D577B00C8ECD9 /* BlackMarketSimulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF540F3B267D577B00C8ECD9 /* BlackMarketSimulator.swift */; };
 		AF5855F125C7517300D7A7AE /* PotionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF5855F025C7517300D7A7AE /* PotionView.swift */; };
 		AF60BC5E253CDEA100DC50DE /* GlobalExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF60BC5D253CDEA100DC50DE /* GlobalExclusions.swift */; };
 		AF60BC63253CE6BD00DC50DE /* GameplaySetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */; };
@@ -111,6 +113,8 @@
 		AF4E49F7252916FE00410D10 /* RuleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleView.swift; sourceTree = "<group>"; };
 		AF4E49FC25291D3100410D10 /* ConditionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionRow.swift; sourceTree = "<group>"; };
 		AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleViewModel.swift; sourceTree = "<group>"; };
+		AF540F35267D574800C8ECD9 /* BlackMarketSimulatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlackMarketSimulatorView.swift; sourceTree = "<group>"; };
+		AF540F3B267D577B00C8ECD9 /* BlackMarketSimulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlackMarketSimulator.swift; sourceTree = "<group>"; };
 		AF5855F025C7517300D7A7AE /* PotionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PotionView.swift; sourceTree = "<group>"; };
 		AF60BC5D253CDEA100DC50DE /* GlobalExclusions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalExclusions.swift; sourceTree = "<group>"; };
 		AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameplaySetup.swift; sourceTree = "<group>"; };
@@ -205,6 +209,7 @@
 				AF1A5E19252550EE0050DE4E /* SetBuilderView.swift */,
 				AF60BC62253CE6BD00DC50DE /* GameplaySetup.swift */,
 				AF60BC67253CED4900DC50DE /* NavigationCardRow.swift */,
+				AF540F35267D574800C8ECD9 /* BlackMarketSimulatorView.swift */,
 			);
 			path = SetBuilder;
 			sourceTree = "<group>";
@@ -315,6 +320,7 @@
 				AF1A5E4C25259A5D0050DE4E /* SetBuilderModel.swift */,
 				AF679A2025FED9D700CCF22B /* CardFilter.swift */,
 				AF540F2B267D0EE900C8ECD9 /* RuleViewModel.swift */,
+				AF540F3B267D577B00C8ECD9 /* BlackMarketSimulator.swift */,
 			);
 			path = viewModels;
 			sourceTree = "<group>";
@@ -533,6 +539,7 @@
 				AF1B6EBF23244FE000ADA74D /* FilterOperation.swift in Sources */,
 				AFCA842E2586BCF5008BBAE3 /* SavedRuleSet+CoreDataClass.swift in Sources */,
 				AF679A2125FED9D700CCF22B /* CardFilter.swift in Sources */,
+				AF540F3C267D577B00C8ECD9 /* BlackMarketSimulator.swift in Sources */,
 				AF60BC68253CED4900DC50DE /* NavigationCardRow.swift in Sources */,
 				AF5855F125C7517300D7A7AE /* PotionView.swift in Sources */,
 				AF1A5E4D25259A5D0050DE4E /* SetBuilderModel.swift in Sources */,
@@ -562,6 +569,7 @@
 				AF1A5E2E25255B320050DE4E /* DebtView.swift in Sources */,
 				AF1B6EC7232463FD00ADA74D /* CardProperty.swift in Sources */,
 				AF1A5E102525500B0050DE4E /* TabContainer.swift in Sources */,
+				AF540F36267D574800C8ECD9 /* BlackMarketSimulatorView.swift in Sources */,
 				AF60BC5E253CDEA100DC50DE /* GlobalExclusions.swift in Sources */,
 				AFCA841B2586A279008BBAE3 /* SavedSetsView.swift in Sources */,
 				AF1A5E29252559700050DE4E /* CostView.swift in Sources */,

--- a/DominionCompanion/utilities/Constants.swift
+++ b/DominionCompanion/utilities/Constants.swift
@@ -39,5 +39,8 @@ struct Constants {
         static let settingsHideWikiLink = "settings_hideWikiLink"
         
         static let savedExcludedCards = "excludedCards"
+
+        static let blackMarketDeckSize = "blackMarketDeckSize"
+        static let blackMarketShuffle = "blackMarketShuffle"
     }
 }

--- a/DominionCompanion/utilities/Settings.swift
+++ b/DominionCompanion/utilities/Settings.swift
@@ -53,6 +53,10 @@ class Settings {
     @UserDefaultsBackedCodable(Constants.SaveKeys.pinnedLandscape) var pinnedLandscape: [Card] = []
 
     @UserDefaultsBackedCodable(Constants.SaveKeys.pinnedRules) var pinnedRules: [Rule] = []
+
+    @UserDefaultsBacked(Constants.SaveKeys.blackMarketDeckSize) var blackMarketDeckSize: Int = 20
+
+    @UserDefaultsBacked(Constants.SaveKeys.blackMarketShuffle) var blackMarketShuffle: Bool = false
 }
 
 

--- a/DominionCompanion/viewModels/BlackMarketSimulator.swift
+++ b/DominionCompanion/viewModels/BlackMarketSimulator.swift
@@ -1,0 +1,45 @@
+//
+//  BlackMarketSimulator.swift
+//  DominionCompanion
+//
+//  Created by Harris Borawski on 6/18/21.
+//  Copyright © 2021 Harris Borawski. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class BlackMarketSimulator: ObservableObject {
+    @Published var visibleCards: [Card] = []
+
+    @Published var deck: [Card]
+
+    @Published var discard: [Card] = []
+
+    init(set: [Card], data: CardData) {
+        let candidates = data.cardsFromChosenExpansions.filter({!set.contains($0)}).shuffled()
+        let count = candidates.count >= Settings.shared.blackMarketDeckSize ? Settings.shared.blackMarketDeckSize : candidates.count
+        deck = Array(candidates[0...(count - 1)])
+    }
+
+    func draw() {
+        guard deck.count > 0 else { return }
+        if deck.count < 3, discard.count > 0 {
+            deck = deck + (Settings.shared.blackMarketShuffle ? discard.shuffled() : discard)
+            discard = []
+        }
+        let drawCount = deck.count >= 3 ? 3 : deck.count
+        visibleCards = Array(deck[0...(drawCount - 1)])
+        deck = Array(deck[drawCount...])
+    }
+
+    func pass() {
+        discard = discard + visibleCards
+        visibleCards = []
+    }
+
+    func buy(_ card: Card) {
+        discard = discard + visibleCards.filter({ $0 != card })
+        visibleCards = []
+    }
+}

--- a/DominionCompanion/viewModels/BlackMarketSimulator.swift
+++ b/DominionCompanion/viewModels/BlackMarketSimulator.swift
@@ -23,7 +23,7 @@ class BlackMarketSimulator: ObservableObject {
     }
 
     func draw() {
-        guard deck.count > 0 else { return }
+        guard deck.count > 0 || discard.count > 0 else { return }
         if deck.count < 3, discard.count > 0 {
             deck = deck + (Settings.shared.blackMarketShuffle ? discard.shuffled() : discard)
             discard = []

--- a/DominionCompanion/views/Rules/RuleView.swift
+++ b/DominionCompanion/views/Rules/RuleView.swift
@@ -77,7 +77,7 @@ struct RuleView<Builder: RuleBuilder>: View  where Builder: ObservableObject {
                 if configurePrecondition {
                     Section(header: Text("Precondition")) {
                         NavigationLink(
-                            destination: RuleView<RuleViewModel>(ruleBuilder: preconditionRuleBuilder, existing: preconditionRule, configurePrecondition: false),
+                            destination: RuleView<RuleViewModel>(ruleBuilder: preconditionRuleBuilder, existing: preconditionRule, configurePrecondition: false).navigationTitle("Precondition"),
                             label: {
                                 HStack {
                                     Image(systemName: "questionmark.diamond")

--- a/DominionCompanion/views/Rules/RulesView.swift
+++ b/DominionCompanion/views/Rules/RulesView.swift
@@ -19,7 +19,7 @@ struct RulesView<Builder: RuleBuilder>: View where Builder: ObservableObject {
     var body: some View {
         List {
             ForEach(ruleBuilder.rules, id: \.self) { rule in
-                NavigationLink(destination: RuleView(ruleBuilder: ruleBuilder, existing: rule)) {
+                NavigationLink(destination: RuleView(ruleBuilder: ruleBuilder, existing: rule).navigationTitle("Rule Edit")) {
                     RuleRow(rule: rule, ruleBuilder: ruleBuilder)
                 }
             }.onDelete(perform: { ruleBuilder.removeRule($0) })
@@ -43,7 +43,7 @@ struct RulesView<Builder: RuleBuilder>: View where Builder: ObservableObject {
         })
         .background(
             NavigationLink(
-                destination: RuleView(ruleBuilder: ruleBuilder),
+                destination: RuleView(ruleBuilder: ruleBuilder).navigationTitle("Rule Creation"),
                 isActive: $editing,
                 label: {
                     EmptyView()

--- a/DominionCompanion/views/SetBuilder/BlackMarketSimulatorView.swift
+++ b/DominionCompanion/views/SetBuilder/BlackMarketSimulatorView.swift
@@ -1,0 +1,88 @@
+//
+//  BlackMarketSimulator.swift
+//  DominionCompanion
+//
+//  Created by Harris Borawski on 6/18/21.
+//  Copyright © 2021 Harris Borawski. All rights reserved.
+//
+
+import SwiftUI
+
+struct BlackMarketSimulatorView: View {
+    var cards: [Card] = []
+
+    @ObservedObject var model: BlackMarketSimulator
+    init(cards: [Card], data: CardData) {
+        model = BlackMarketSimulator(set: cards, data: data)
+    }
+    var body: some View {
+        VStack {
+            GeometryReader { geo in
+                VStack {
+                    ForEach(model.visibleCards, id: \.id) { card in
+                        HStack(alignment: .center) {
+                            NavigationLink(
+                                destination: CardView<EmptyView>(card: card)
+                            ) {
+                                if let image = card.image() {
+                                    Image(uiImage: image)
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: geo.size.width / 3)
+                                } else {
+                                    Text(card.name)
+                                }
+                            }
+                            VStack(alignment: .leading) {
+                                HStack {
+                                    CostView(value: card.cost)
+                                    if card.debt > 0 {
+                                        DebtView(value: card.debt)
+                                    }
+                                    Text(card.name)
+                                }
+
+                                Button(action: {
+                                    model.buy(card)
+                                }, label: {
+                                    HStack {
+                                        Image(systemName: "dollarsign.circle.fill")
+                                        Text("Buy")
+                                    }.foregroundColor(.white).padding(8).frame(maxWidth: .infinity)
+                                }).background(RoundedRectangle(cornerRadius: 4).foregroundColor(.blue))
+                            }
+                            Spacer()
+                        }.frame(maxWidth: .infinity)
+                    }
+                }
+            }
+            Spacer()
+            HStack(spacing: 24) {
+                NavigationLink(destination: CardsView<EmptyView>(cards: (model.deck + model.discard).sorted(by: Utilities.alphabeticSort(card1:card2:)))) {
+                    HStack {
+                        Image("Deck")
+                        Text("\(model.deck.count + model.discard.count)")
+                    }
+                }
+                Button(action: model.draw, label: {
+                    HStack {
+                        Image("Card")
+                        Text("Reveal")
+                    }
+                }).disabled(!model.visibleCards.isEmpty)
+                Button(action: model.pass, label: {
+                    HStack {
+                        Image(systemName: "arrow.turn.up.right")
+                        Text("Pass")
+                    }
+                }).disabled(model.visibleCards.isEmpty)
+            }.padding(8).frame(maxWidth: .infinity)
+        }.frame(maxWidth: .infinity).navigationTitle("Black Market")
+    }
+}
+
+struct BlackMarketSimulator_Previews: PreviewProvider {
+    static var previews: some View {
+        BlackMarketSimulatorView(cards: [], data: CardData.shared)
+    }
+}

--- a/DominionCompanion/views/SetBuilder/GameplaySetup.swift
+++ b/DominionCompanion/views/SetBuilder/GameplaySetup.swift
@@ -33,6 +33,11 @@ struct GameplaySetup: View {
     @ViewBuilder
     var body: some View {
         List {
+            if model.cards.contains(where: {$0.name == "Black Market"}) {
+                NavigationLink(destination: BlackMarketSimulatorView(cards: model.cards, data: cardData)) {
+                    Text("Black Market Simulator")
+                }
+            }
             cardSection("In Supply", model.cards)
             if model.notInSupply.count > 0 {
                 cardSection("Not In Supply", model.notInSupply)

--- a/DominionCompanion/views/Settings/SettingsView.swift
+++ b/DominionCompanion/views/Settings/SettingsView.swift
@@ -33,6 +33,9 @@ struct SettingsView: View {
     @AppStorage(Constants.SaveKeys.settingsShowExpansionsWhenBuilding) var showExpansions: Bool = false
     @AppStorage(Constants.SaveKeys.settingsGameplaySortMode) var gameplaySortMode: SortMode = .cost
 
+    @AppStorage(Constants.SaveKeys.blackMarketDeckSize) var blackMarketDeckSize: Int = Settings.shared.blackMarketDeckSize
+    @AppStorage(Constants.SaveKeys.blackMarketShuffle) var blackMarketShuffle: Bool = Settings.shared.blackMarketShuffle
+
     var body: some View {
         NavigationView {
             List {
@@ -76,6 +79,12 @@ struct SettingsView: View {
                             gameplaySortMode = mode
                         }
                     }
+                }
+                Section(header: Text("Black Market")) {
+                    ListChoice(title: "Black Market Deck Size", value: "\(blackMarketDeckSize)", values: Array(0...49).map { "\($0 + 1)" }) { val in
+                        blackMarketDeckSize = Int(val) ?? 20
+                    }
+                    Toggle("Shuffle after all cards seen", isOn: $blackMarketShuffle)
                 }
                 Section(header: Text("Miscellaneous")) {
                     NavigationLink(destination: GlobalExclusions()) {

--- a/UnitTests/viewModels/BlackMarketSimulatorTests.swift
+++ b/UnitTests/viewModels/BlackMarketSimulatorTests.swift
@@ -1,0 +1,133 @@
+//
+//  BlackMarketSimulatorTests.swift
+//  UnitTests
+//
+//  Created by Harris Borawski on 6/18/21.
+//  Copyright © 2021 Harris Borawski. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import DominionCompanion
+
+class BlackMarketSimulatorTests: XCTestCase {
+    override func setUp() {
+        Settings.shared.chosenExpansions = []
+        Settings.shared.blackMarketShuffle = false
+    }
+    func testDiscardLoop() {
+        Settings.shared.chosenExpansions = ["Base"]
+        Settings.shared.blackMarketDeckSize = 3
+        let sim = BlackMarketSimulator(set: [
+            TestData.getCard("Laboratory"),
+            TestData.getCard("Village"),
+            TestData.getCard("Festival")
+        ], data: CardData.shared)
+
+        sim.draw()
+
+        XCTAssertEqual(sim.visibleCards.count, 3)
+        XCTAssertEqual(sim.deck.count, 0)
+        XCTAssertEqual(sim.discard.count, 0)
+
+        sim.pass()
+
+        XCTAssertEqual(sim.visibleCards.count, 0)
+        XCTAssertEqual(sim.deck.count, 0)
+        XCTAssertEqual(sim.discard.count, 3)
+
+        sim.draw()
+
+        XCTAssertEqual(sim.visibleCards.count, 3)
+        XCTAssertEqual(sim.deck.count, 0)
+        XCTAssertEqual(sim.discard.count, 0)
+    }
+
+    func testDiscardLoopPartial() {
+        Settings.shared.chosenExpansions = ["Base"]
+        Settings.shared.blackMarketDeckSize = 4
+        let sim = BlackMarketSimulator(set: [
+            TestData.getCard("Laboratory"),
+            TestData.getCard("Village"),
+            TestData.getCard("Festival")
+        ], data: CardData.shared)
+
+        sim.draw()
+
+        XCTAssertEqual(sim.visibleCards.count, 3)
+        XCTAssertEqual(sim.deck.count, 1)
+        XCTAssertEqual(sim.discard.count, 0)
+
+        sim.pass()
+
+        XCTAssertEqual(sim.visibleCards.count, 0)
+        XCTAssertEqual(sim.deck.count, 1)
+        XCTAssertEqual(sim.discard.count, 3)
+
+        sim.draw()
+
+        XCTAssertEqual(sim.visibleCards.count, 3)
+        XCTAssertEqual(sim.deck.count, 1)
+        XCTAssertEqual(sim.discard.count, 0)
+    }
+
+    func testDiscardShuffle() {
+        Settings.shared.chosenExpansions = ["Base"]
+        Settings.shared.blackMarketDeckSize = 3
+        Settings.shared.blackMarketShuffle = true
+        let sim = BlackMarketSimulator(set: [
+            TestData.getCard("Laboratory"),
+            TestData.getCard("Village"),
+            TestData.getCard("Festival")
+        ], data: CardData.shared)
+
+        // Technically shuffling/randomization can produce the same order
+        var shuffled = false
+        var count = 0
+        while !shuffled, count < 20 {
+            sim.draw()
+
+            let copy = sim.visibleCards.map(\.name).joined()
+
+            sim.pass()
+
+            sim.draw()
+
+            if copy != sim.visibleCards.map(\.name).joined() {
+                shuffled = true
+            }
+            count += 1
+        }
+
+        XCTAssertTrue(shuffled)
+
+    }
+
+    func testBuyCard() {
+        Settings.shared.chosenExpansions = ["Base"]
+        Settings.shared.blackMarketDeckSize = 4
+        let sim = BlackMarketSimulator(set: [
+            TestData.getCard("Laboratory"),
+            TestData.getCard("Village"),
+            TestData.getCard("Festival")
+        ], data: CardData.shared)
+
+        sim.draw()
+
+        XCTAssertEqual(sim.visibleCards.count, 3)
+        XCTAssertEqual(sim.deck.count, 1)
+        XCTAssertEqual(sim.discard.count, 0)
+
+        sim.buy(sim.visibleCards[0])
+
+        XCTAssertEqual(sim.visibleCards.count, 0)
+        XCTAssertEqual(sim.deck.count, 1)
+        XCTAssertEqual(sim.discard.count, 2)
+
+        sim.draw()
+
+        XCTAssertEqual(sim.visibleCards.count, 3)
+        XCTAssertEqual(sim.deck.count, 0)
+        XCTAssertEqual(sim.discard.count, 0)
+    }
+}


### PR DESCRIPTION
Resolves #14 

Implements a black market deck simulator, where you can go through a virtual deck of black market cards, and mark cards as purchased

settings for deck size, and the option to shuffle the discarded cards (like dominion online does)

https://user-images.githubusercontent.com/1325154/122625361-a4c56a00-d059-11eb-8a13-d3604653cd85.mov

