### PR TITLE
enable pinning from expansion selection screen

### DIFF
--- a/DominionCompanion.xcodeproj/project.pbxproj
+++ b/DominionCompanion.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		AF9186BC2793707A0077D16F /* ImageGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9186BB2793707A0077D16F /* ImageGenerator.swift */; };
 		AF9186C427937B320077D16F /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9186C327937B320077D16F /* ShareSheet.swift */; };
 		AF9186C827938DF70077D16F /* ImageGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9186C727938DF70077D16F /* ImageGeneratorTests.swift */; };
+		AF9186CE279393590077D16F /* PinButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9186CD279393590077D16F /* PinButton.swift */; };
 		AFA6638925858D5F00E641D8 /* SetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFA6638825858D5F00E641D8 /* SetsView.swift */; };
 		AFB96A9A2443E6DA00F2046D /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB96A992443E6DA00F2046D /* Settings.swift */; };
 		AFBD15A825EAE51E0002275A /* RecommendedSetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBD15A725EAE51E0002275A /* RecommendedSetsTests.swift */; };
@@ -136,6 +137,7 @@
 		AF9186BB2793707A0077D16F /* ImageGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGenerator.swift; sourceTree = "<group>"; };
 		AF9186C327937B320077D16F /* ShareSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSheet.swift; sourceTree = "<group>"; };
 		AF9186C727938DF70077D16F /* ImageGeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageGeneratorTests.swift; sourceTree = "<group>"; };
+		AF9186CD279393590077D16F /* PinButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinButton.swift; sourceTree = "<group>"; };
 		AFA6638825858D5F00E641D8 /* SetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetsView.swift; sourceTree = "<group>"; };
 		AFB96A992443E6DA00F2046D /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		AFBD15A725EAE51E0002275A /* RecommendedSetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendedSetsTests.swift; sourceTree = "<group>"; };
@@ -342,6 +344,7 @@
 				AF60BC6C253D0CA200DC50DE /* SwipableRow.swift */,
 				AFBD15C225EB40580002275A /* ToastWrapper.swift */,
 				AF9186C327937B320077D16F /* ShareSheet.swift */,
+				AF9186CD279393590077D16F /* PinButton.swift */,
 			);
 			path = utilities;
 			sourceTree = "<group>";
@@ -597,6 +600,7 @@
 				AF9186BC2793707A0077D16F /* ImageGenerator.swift in Sources */,
 				AF1A5E682529101C0050DE4E /* RuleRow.swift in Sources */,
 				AFC1BA66246A24E400298F75 /* SavedSets.xcdatamodeld in Sources */,
+				AF9186CE279393590077D16F /* PinButton.swift in Sources */,
 				AFE8EE7522A4B830008E09B2 /* Card.swift in Sources */,
 				AF80D70C2364DD7100FDC4D6 /* SetModel.swift in Sources */,
 			);

--- a/DominionCompanion/views/Containers/TabContainer.swift
+++ b/DominionCompanion/views/Containers/TabContainer.swift
@@ -19,11 +19,7 @@ struct TabContainer: View {
                 Text("Set Builder")
             }
             NavigationView {
-                CardsView(cards: cardData.allCards, title: nil, accessory: { card in
-                    Button(action: {setBuilder.pin(card)}, label: {
-                        Image(systemName: setBuilder.pinnedLandscape.contains(card) || setBuilder.pinnedCards.contains(card) ? "checkmark.circle.fill" : "checkmark.circle").foregroundColor(.blue)
-                    }).buttonStyle(PlainButtonStyle())
-                }, showOnRow: false)
+                CardsView(cards: cardData.allCards, title: nil, accessory: { PinButton(card: $0) }, showOnRow: false)
             }.tabItem {
                 Image("Card")
                 Text("Cards")

--- a/DominionCompanion/views/SetBuilder/ExpansionSelection.swift
+++ b/DominionCompanion/views/SetBuilder/ExpansionSelection.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ExpansionSelection: View {
     @EnvironmentObject var cardData: CardData
+    @EnvironmentObject var setBuilder: SetBuilderModel
     
     @ObservedObject @UserDefaultsBacked(Constants.SaveKeys.chosenExpansions) var chosenExpansions: [String] = []
 
@@ -52,7 +53,7 @@ struct ExpansionSelection: View {
         .navigationTitle("Expansions")
         .background(
             NavigationLink(
-                destination: CardsView(cards: cardData.allCards.filter { $0.expansion == selectedExpansion }, title: selectedExpansion) {_ in EmptyView()},
+                destination: CardsView(cards: cardData.allCards.filter { $0.expansion == selectedExpansion }, title: selectedExpansion) { PinButton(card: $0) },
                 isActive: $viewExpansion,
                 label: {
                     EmptyView()

--- a/DominionCompanion/views/SetBuilder/NavigationCardRow.swift
+++ b/DominionCompanion/views/SetBuilder/NavigationCardRow.swift
@@ -16,18 +16,9 @@ struct NavigationCardRow: View {
     var showExpansion = false
     @ViewBuilder
     var body: some View {
-        let pinButton = { c in
-            Button(action: {setBuilder.pin(c)}, label: {
-                if setBuilder.pinnedCards.contains(c) || setBuilder.pinnedLandscape.contains(c) {
-                    Image(systemName: "checkmark.circle.fill").foregroundColor(.blue)
-                } else {
-                    Image(systemName: "checkmark.circle").foregroundColor(.gray)
-                }
-            }).buttonStyle(PlainButtonStyle())
-        }
         let pinned = setBuilder.pinnedCards.contains(card) || setBuilder.pinnedLandscape.contains(card)
         NavigationLink(
-            destination: CardView(card: card, accessory: pinButton).navigationBarTitleDisplayMode(.large),
+            destination: CardView(card: card, accessory: { PinButton(card: $0) }).navigationBarTitleDisplayMode(.large),
             label: {
                 CardRow(card: card) {
                     HStack {
@@ -55,6 +46,12 @@ struct NavigationCardRow: View {
                             Image(systemName: "checkmark")
                             Text("Pin")
                         }
+                })
+                Button(action: { setBuilder.pinnedCards = []}, label: {
+                    HStack {
+                        Image(systemName: "xmark")
+                        Text("Unpin All")
+                    }
                 })
             }
             .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 1, trailing: 8))

--- a/DominionCompanion/views/utilities/PinButton.swift
+++ b/DominionCompanion/views/utilities/PinButton.swift
@@ -1,0 +1,33 @@
+//
+//  PinButton.swift
+//  DominionCompanion
+//
+//  Created by Harris Borawski on 1/15/22.
+//  Copyright © 2022 Harris Borawski. All rights reserved.
+//
+
+import SwiftUI
+
+struct PinButton: View {
+    @EnvironmentObject var setBuilder: SetBuilderModel
+
+    var image: Image {
+        Image(systemName: setBuilder.pinnedLandscape.contains(card) || setBuilder.pinnedCards.contains(card) ? "checkmark.circle.fill" : "checkmark.circle")
+    }
+
+    var card: Card
+    var body: some View {
+        Button(action: {
+                setBuilder.pin(card)
+        }, label: {
+            image.foregroundColor(.blue)
+        })
+        .buttonStyle(PlainButtonStyle())
+    }
+}
+
+//struct PinButton_Previews: PreviewProvider {
+//    static var previews: some View {
+//        PinButton(card: "")
+//    }
+//}


### PR DESCRIPTION
Pinning while looking at just an expansions worth of cards is quite helpful, especially with a filter